### PR TITLE
Upgrade foundry-js to 0.21.0

### DIFF
--- a/ui/extensions/user-preferences/package-lock.json
+++ b/ui/extensions/user-preferences/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@crowdstrike/falcon-shoelace": "0.4.0",
-        "@crowdstrike/foundry-js": "0.20.0",
+        "@crowdstrike/foundry-js": "0.21.0",
         "@crowdstrike/tailwind-toucan-base": "5.0.0",
         "@shoelace-style/shoelace": "2.20.1",
         "react": "19.2.1",
@@ -1919,9 +1919,9 @@
       "license": "MIT"
     },
     "node_modules/@crowdstrike/foundry-js": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-js/-/foundry-js-0.20.0.tgz",
-      "integrity": "sha512-GINw0WJqw1lbuOZIizOUpQBYuQ5DXMoaQQSmm2PwoDOfyR3k2//Sw5jlw7LEjQk1y6/L1JoXgf9/GoJaiyi2Pw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-js/-/foundry-js-0.21.0.tgz",
+      "integrity": "sha512-anhEJJQXSGnpwOMhyYquXyLRQx1OdsqZ205xewLt3LUccz6hZpAJRFs6M+u/y4xzV8xXQ0+Y0Swz/JbHXXYLdQ==",
       "license": "MIT",
       "dependencies": {
         "emittery": "1.2.0",

--- a/ui/extensions/user-preferences/package.json
+++ b/ui/extensions/user-preferences/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@crowdstrike/falcon-shoelace": "0.4.0",
-    "@crowdstrike/foundry-js": "0.20.0",
+    "@crowdstrike/foundry-js": "0.21.0",
     "@crowdstrike/tailwind-toucan-base": "5.0.0",
     "@shoelace-style/shoelace": "2.20.1",
     "react": "19.2.1",

--- a/ui/extensions/user-preferences/src/dist/app.js
+++ b/ui/extensions/user-preferences/src/dist/app.js
@@ -3566,6 +3566,9 @@ class Navigation {
       }
     });
   }
+  /**
+   * @deprecated Use navigateTo directly
+   */
   async onClick(event, defaultTarget = '_self', defaultType = 'falcon') {
     if (!(event instanceof Event)) {
       throw Error('"event" property should be subclass of Event');


### PR DESCRIPTION
Upgrades @crowdstrike/foundry-js 0.20.0 -> 0.21.0.

All tests and linting pass.