### PR TITLE
Fix iframe selector for Charlotte AI compatibility

### DIFF
--- a/e2e/src/pages/HostPanelExtensionPage.ts
+++ b/e2e/src/pages/HostPanelExtensionPage.ts
@@ -56,10 +56,10 @@ export abstract class HostPanelExtensionPage extends SocketNavigationPage {
         await extensionHeading.click();
         this.logger.info(`Clicked to expand ${this.extensionName} extension`);
 
-        await expect(this.page.locator('iframe')).toBeVisible({ timeout: 15000 });
+        await expect(this.page.locator('iframe[name="portal"]')).toBeVisible({ timeout: 15000 });
         this.logger.info('Extension iframe loaded');
 
-        const iframe: FrameLocator = this.page.frameLocator('iframe');
+        const iframe: FrameLocator = this.page.frameLocator('iframe[name="portal"]');
         await this.verifyExtensionContent(iframe);
 
         this.logger.success(`${this.extensionName} extension renders correctly`);


### PR DESCRIPTION
The Falcon console now includes a Charlotte AI iframe on every page, causing Playwright's strict mode to fail with `locator('iframe') resolved to 2 elements`. Changed bare `iframe` selectors to `iframe[name="portal"]` which positively targets the Foundry extension iframe (confirmed via DOM inspection that host panel extensions also use `name="portal"`).